### PR TITLE
Support non-Guid IDs

### DIFF
--- a/Edge10.CouchDb.Client.Tests/Edge10.CouchDb.Client.Tests.csproj
+++ b/Edge10.CouchDb.Client.Tests/Edge10.CouchDb.Client.Tests.csproj
@@ -73,6 +73,9 @@
       <Name>Edge10.CouchDb.Client</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Edge10.CouchDb.Client.Tests/TestCouchApi.cs
+++ b/Edge10.CouchDb.Client.Tests/TestCouchApi.cs
@@ -515,9 +515,9 @@ namespace Edge10.CouchDb.Client.Tests
 			SetupViewParameters(out viewParameters, out expectedUrl);
 
 			var data = new[] {
-				Guid.NewGuid(),
-				Guid.NewGuid(),
-				Guid.NewGuid(),
+				Guid.NewGuid().ToString(),
+				Guid.NewGuid().ToString(),
+				Guid.NewGuid().ToString(),
 			};
 			var couchResult = new ViewResult<string, object> { TotalRows = data.Length };
 
@@ -1430,7 +1430,7 @@ namespace Edge10.CouchDb.Client.Tests
 		[Test]
 		public async Task GetLatestDocumentRevisions_Ignores_Empty_Array()
 		{
-			var result = await _couchApi.GetLatestDocumentRevisions(Enumerable.Empty<Guid>());
+			var result = await _couchApi.GetLatestDocumentRevisions(Enumerable.Empty<string>());
 			Assert.AreEqual(0, result.Count, "No results should be returned");
 			_httpClient.Verify(c => c.PostAsync(
 				It.IsAny<string>(),
@@ -1441,8 +1441,8 @@ namespace Edge10.CouchDb.Client.Tests
 		public async Task GetLatestDocumentRevisions_Returns_Documents_From_Server()
 		{
 			//two unique ids, another one that won't be returned from the request and one duplicate
-			var duplicateId = Guid.NewGuid();
-			var ids         = new[] { Guid.NewGuid(), duplicateId, Guid.NewGuid(), duplicateId };
+			var duplicateId = Guid.NewGuid().ToString();
+			var ids         = new[] { Guid.NewGuid().ToString(), duplicateId, Guid.NewGuid().ToString(), duplicateId };
 			var expectedUrl = "https://server:1234/database/_all_docs";
 
 			var changes = new ViewResult<object, ChangeRevision>();
@@ -1488,8 +1488,8 @@ namespace Edge10.CouchDb.Client.Tests
 		public async Task GetLatestDocumentRevisions_Splits_Large_Requests_Into_Packets()
 		{
 			//three unique ids, another one that won't be returned from the request and one duplicate
-			var duplicateId = Guid.NewGuid();
-			var ids         = new[] { Guid.NewGuid(), Guid.NewGuid(), duplicateId, Guid.NewGuid(), duplicateId };
+			var duplicateId = Guid.NewGuid().ToString();
+			var ids         = new[] { Guid.NewGuid().ToString(), Guid.NewGuid().ToString(), duplicateId, Guid.NewGuid().ToString(), duplicateId };
 			var expectedUrl = "https://server:1234/database/_all_docs";
 
 			var packet1Changes = new ViewResult<object, ChangeRevision>();

--- a/Edge10.CouchDb.Client/CouchApi.cs
+++ b/Edge10.CouchDb.Client/CouchApi.cs
@@ -477,12 +477,12 @@ namespace Edge10.CouchDb.Client
 		/// <returns>
 		/// The latest revision for each document, or <c>null</c> if no change can be found.
 		/// </returns>
-		public async Task<IDictionary<Guid, ChangeRevision>> GetLatestDocumentRevisions(IEnumerable<Guid> documentIds)
+		public async Task<IDictionary<string, ChangeRevision>> GetLatestDocumentRevisions(IEnumerable<string> documentIds)
 		{
 			documentIds.ThrowIfNull(nameof(documentIds));
 
 			var distinctIds = documentIds.Distinct().ToArray();
-			if (!distinctIds.Any()) return new Dictionary<Guid, ChangeRevision>();
+			if (!distinctIds.Any()) return new Dictionary<string, ChangeRevision>();
 
 			var url = $"{_url}/{_databaseName}/_all_docs";
 
@@ -506,7 +506,7 @@ namespace Edge10.CouchDb.Client
 			}
 
 			var idBlocks = SplitToBlocks(distinctIds, MaxDocumentsPerRequest);
-			var results  = new Dictionary<Guid, ChangeRevision>();
+			var results  = new Dictionary<string, ChangeRevision>();
 
 			//note: running these sequentially to avoid multiple
 			//simultaneous threads causing memory problems
@@ -528,7 +528,7 @@ namespace Edge10.CouchDb.Client
 		/// </summary>
 		/// <param name="viewParameters">The view parameters.</param>
 		/// <returns>The IDs of the documents returned by the view.</returns>
-		public async Task<IEnumerable<Guid>> GetViewDocumentIdsAsync(IViewParameters viewParameters)
+		public async Task<IEnumerable<string>> GetViewDocumentIdsAsync(IViewParameters viewParameters)
 		{
 			var viewResult = await GetListResult<ViewResult<object, object>>(viewParameters);
 			return viewResult.Rows.Select(r => r.Id);

--- a/Edge10.CouchDb.Client/ICouchApi.cs
+++ b/Edge10.CouchDb.Client/ICouchApi.cs
@@ -110,7 +110,7 @@ namespace Edge10.CouchDb.Client
 		/// </summary>
 		/// <param name="viewParameters">The view parameters.</param>
 		/// <returns>The IDs of the documents returned by the view.</returns>
-		Task<IEnumerable<Guid>> GetViewDocumentIdsAsync(IViewParameters viewParameters);
+		Task<IEnumerable<string>> GetViewDocumentIdsAsync(IViewParameters viewParameters);
 
 		/// <summary>
 		/// Retrieves the document with the specified <paramref name="documentId"/> then serializes
@@ -231,7 +231,7 @@ namespace Edge10.CouchDb.Client
 		/// <returns>
 		/// The latest revision for each document, or <c>null</c> if no change can be found.
 		/// </returns>
-		Task<IDictionary<Guid, ChangeRevision>> GetLatestDocumentRevisions(IEnumerable<Guid> documentIds);
+		Task<IDictionary<string, ChangeRevision>> GetLatestDocumentRevisions(IEnumerable<string> documentIds);
 
 		/// <summary>
 		/// Executes the specified view and parses the result into <typeparamref name="TResult"/>.

--- a/Edge10.CouchDb.Client/Results/ViewResultRow.cs
+++ b/Edge10.CouchDb.Client/Results/ViewResultRow.cs
@@ -17,7 +17,7 @@ namespace Edge10.CouchDb.Client.Results
 		/// The ID.
 		/// </value>
 		[JsonProperty("id")]
-		public Guid Id { get; set; }
+		public string Id { get; set; }
 
 		/// <summary>
 		/// Gets or sets the key that identifies this row.


### PR DESCRIPTION
Fixes #4

* Allow `ViewResultRow` to have a string `Id`
* Removed all erroneous references to `Guid`!