### PR TITLE
#TFS14662 Optionally specify HttpClientHandler

### DIFF
--- a/Edge10.CouchDb.Client.Tests/packages.config
+++ b/Edge10.CouchDb.Client.Tests/packages.config
@@ -8,4 +8,5 @@
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net452" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net452" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net452" />
 </packages>

--- a/Edge10.CouchDb.Client/CouchApi.cs
+++ b/Edge10.CouchDb.Client/CouchApi.cs
@@ -39,8 +39,12 @@ namespace Edge10.CouchDb.Client
 		/// <param name="connectionString">The connection string.</param>
 		/// <param name="eventLog">The couch event log</param>
 		/// <param name="serializationStrategy">The serialization strategy.</param>
-		public CouchApi(ICouchDbConnectionStringBuilder connectionString, ICouchEventLog eventLog = null, SerializationStrategy serializationStrategy = null) 
-			: this(connectionString, new HttpClientFacade(new HttpClientHandler()), eventLog ?? NullCouchEventLog.Instance, serializationStrategy)
+		/// <param name="httpClientHandler">The HTTP client handler.</param>
+		public CouchApi(ICouchDbConnectionStringBuilder connectionString, ICouchEventLog eventLog = null, SerializationStrategy serializationStrategy = null, HttpClientHandler httpClientHandler = null) 
+			: this(connectionString, 
+				  new HttpClientFacade(httpClientHandler ?? new HttpClientHandler()), 
+				  eventLog ?? NullCouchEventLog.Instance, 
+				  serializationStrategy)
 		{
 		}
 


### PR DESCRIPTION
Allow consumers to optionally specify a custom `HttpClientHandler`
implementation to `CouchApi`