### PR TITLE
Added support for single item key view parameter

### DIFF
--- a/Edge10.CouchDb.Client.Tests/TestViewParameters.cs
+++ b/Edge10.CouchDb.Client.Tests/TestViewParameters.cs
@@ -59,7 +59,7 @@ namespace Edge10.CouchDb.Client.Tests
 		}
 
 		[Test]
-		public void CreateQueryString_Unwraps_Single_Key_Item()
+		public void CreateQueryString_Supports_Single_Key_Item()
 		{
 			var parameters = new ViewParameters("view", "designdoc")
 			{
@@ -69,7 +69,21 @@ namespace Edge10.CouchDb.Client.Tests
 			parameters.QueryStringParameters.Add("custom", "123");
 
 			var queryString = parameters.CreateQueryString();
-			Assert.IsTrue(queryString.Contains("key=%22ten%22"), "Key was not set");
+			Assert.That(queryString, Does.Contain("key=%22ten%22"), "Key was not set");
+		}
+
+		[Test]
+		public void CreateQueryString_Ignores_Empty_Array_For_Key()
+		{
+			var parameters = new ViewParameters("view", "designdoc")
+			{
+				Key = new object[0]
+			};
+
+			parameters.QueryStringParameters.Add("custom", "123");
+
+			var queryString = parameters.CreateQueryString();
+			Assert.That(queryString, Does.Not.Contain("key"), "Key was set");
 		}
 
 		[Test]

--- a/Edge10.CouchDb.Client.Tests/TestViewParameters.cs
+++ b/Edge10.CouchDb.Client.Tests/TestViewParameters.cs
@@ -87,6 +87,34 @@ namespace Edge10.CouchDb.Client.Tests
 		}
 
 		[Test]
+		public void CreateQueryString_Null_Array_For_Key()
+		{
+			var parameters = new ViewParameters("view", "designdoc")
+			{
+				Key = (object[]) null
+			};
+
+			parameters.QueryStringParameters.Add("custom", "123");
+
+			var queryString = parameters.CreateQueryString();
+			Assert.That(queryString, Does.Not.Contain("key"), "Key was set");
+		}
+
+		[Test]
+		public void CreateQueryString_Null_String_For_Key()
+		{
+			var parameters = new ViewParameters("view", "designdoc")
+			{
+				Key = (string) null
+			};
+
+			parameters.QueryStringParameters.Add("custom", "123");
+
+			var queryString = parameters.CreateQueryString();
+			Assert.That(queryString, Does.Not.Contain("key"), "Key was set");
+		}
+
+		[Test]
 		public void CreateQueryString_Builds_QueryString_From_Only_Custom_Parameters()
 		{
 			var parameters = new ViewParameters("view", "design");

--- a/Edge10.CouchDb.Client.Tests/TestViewParameters.cs
+++ b/Edge10.CouchDb.Client.Tests/TestViewParameters.cs
@@ -59,6 +59,20 @@ namespace Edge10.CouchDb.Client.Tests
 		}
 
 		[Test]
+		public void CreateQueryString_Unwraps_Single_Key_Item()
+		{
+			var parameters = new ViewParameters("view", "designdoc")
+			{
+				Key = "ten"
+			};
+
+			parameters.QueryStringParameters.Add("custom", "123");
+
+			var queryString = parameters.CreateQueryString();
+			Assert.IsTrue(queryString.Contains("key=%22ten%22"), "Key was not set");
+		}
+
+		[Test]
 		public void CreateQueryString_Builds_QueryString_From_Only_Custom_Parameters()
 		{
 			var parameters = new ViewParameters("view", "design");

--- a/Edge10.CouchDb.Client/Edge10.CouchDb.Client.csproj
+++ b/Edge10.CouchDb.Client/Edge10.CouchDb.Client.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ICouchQueryParameters.cs" />
     <Compile Include="IPagedResult.cs" />
     <Compile Include="IViewParameters.cs" />
+    <Compile Include="KeyParameter.cs" />
     <Compile Include="NullCouchEventLog.cs" />
     <Compile Include="PagedResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Edge10.CouchDb.Client/IViewParameters.cs
+++ b/Edge10.CouchDb.Client/IViewParameters.cs
@@ -50,7 +50,7 @@ namespace Edge10.CouchDb.Client
 		/// <summary>
 		/// Gets or sets a key.
 		/// </summary>
-		IEnumerable<object> Key { get; set; }
+		KeyParameter Key { get; set; }
 
 		/// <summary>
 		/// Gets or sets a start key.

--- a/Edge10.CouchDb.Client/KeyParameter.cs
+++ b/Edge10.CouchDb.Client/KeyParameter.cs
@@ -11,18 +11,22 @@ namespace Edge10.CouchDb.Client
 
 		public static implicit operator KeyParameter(string key)
 		{
-			return new KeyParameter
-			{
-				FormattedValue = WebUtility.UrlEncode(JsonConvert.SerializeObject(key, Formatting.None, new IsoDateTimeConverter()))
-			};
+			return ToKeyParameter(key);
 		}
 
 		public static implicit operator KeyParameter(Array key)
 		{
-			var value = JsonConvert.SerializeObject(key, Formatting.None, new IsoDateTimeConverter());
+			if (key.Length == 0)
+				return null;
+
+			return ToKeyParameter(key);
+		}
+
+		private static KeyParameter ToKeyParameter(object key)
+		{
 			return new KeyParameter
 			{
-				FormattedValue = WebUtility.UrlEncode(value)
+				FormattedValue = WebUtility.UrlEncode(JsonConvert.SerializeObject(key, Formatting.None, new IsoDateTimeConverter()))
 			};
 		}
 	}

--- a/Edge10.CouchDb.Client/KeyParameter.cs
+++ b/Edge10.CouchDb.Client/KeyParameter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Net;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Edge10.CouchDb.Client
+{
+	public class KeyParameter
+	{
+		public string FormattedValue { get; private set; }
+
+		public static implicit operator KeyParameter(string key)
+		{
+			return new KeyParameter
+			{
+				FormattedValue = WebUtility.UrlEncode(JsonConvert.SerializeObject(key, Formatting.None, new IsoDateTimeConverter()))
+			};
+		}
+
+		public static implicit operator KeyParameter(Array key)
+		{
+			var value = JsonConvert.SerializeObject(key, Formatting.None, new IsoDateTimeConverter());
+			return new KeyParameter
+			{
+				FormattedValue = WebUtility.UrlEncode(value)
+			};
+		}
+	}
+}

--- a/Edge10.CouchDb.Client/KeyParameter.cs
+++ b/Edge10.CouchDb.Client/KeyParameter.cs
@@ -11,12 +11,15 @@ namespace Edge10.CouchDb.Client
 
 		public static implicit operator KeyParameter(string key)
 		{
+			if (key == null)
+				return null;
+
 			return ToKeyParameter(key);
 		}
 
 		public static implicit operator KeyParameter(Array key)
 		{
-			if (key.Length == 0)
+			if (key == null || key.Length == 0)
 				return null;
 
 			return ToKeyParameter(key);

--- a/Edge10.CouchDb.Client/ViewParameters.cs
+++ b/Edge10.CouchDb.Client/ViewParameters.cs
@@ -153,13 +153,6 @@ namespace Edge10.CouchDb.Client
 			return builder.ToString();
 		}
 
-		private string FormatKeyParam(object[] key)
-		{
-			if (key.Length == 1)
-				return WebUtility.UrlEncode(JsonConvert.SerializeObject(key[0], Formatting.None, new IsoDateTimeConverter()));
-			return PrepareArrayValue(key);
-		}
-
 		private string PrepareArrayValue(IEnumerable<object> values)
 		{
 			var valuesArray = values as object[] ?? values.ToArray();

--- a/Edge10.CouchDb.Client/ViewParameters.cs
+++ b/Edge10.CouchDb.Client/ViewParameters.cs
@@ -71,7 +71,7 @@ namespace Edge10.CouchDb.Client
 		/// <summary>
 		/// Gets or sets a key.
 		/// </summary>
-		public IEnumerable<object> Key { get; set; }
+		public KeyParameter Key { get; set; }
 
 		/// <summary>
 		/// Gets or sets the keys to be posted to the view.  If specified, these
@@ -131,8 +131,8 @@ namespace Edge10.CouchDb.Client
 				parameters.Add("inclusive_end", InclusiveEnd.Value.ToString().ToLower());
 			if (Skip.HasValue)
 				parameters.Add("skip", Skip.Value.ToString());
-			if (Key != null && Key.Any())
-				parameters.Add("key", PrepareArrayValue(Key));
+			if (Key != null)
+				parameters.Add("key", Key.FormattedValue);
 			if (StartKey != null && StartKey.Any())
 				parameters.Add("startkey", PrepareArrayValue(StartKey));
 			if (EndKey != null && EndKey.Any())
@@ -151,6 +151,13 @@ namespace Edge10.CouchDb.Client
 			}
 
 			return builder.ToString();
+		}
+
+		private string FormatKeyParam(object[] key)
+		{
+			if (key.Length == 1)
+				return WebUtility.UrlEncode(JsonConvert.SerializeObject(key[0], Formatting.None, new IsoDateTimeConverter()));
+			return PrepareArrayValue(key);
 		}
 
 		private string PrepareArrayValue(IEnumerable<object> values)


### PR DESCRIPTION
We need this to support cases like `emit(doc.someProperty, null)`